### PR TITLE
Finish changes for ticket #167 & sizing adjustments

### DIFF
--- a/v2.0/src/Components/Pages/EventsPage/OneEventPage.js
+++ b/v2.0/src/Components/Pages/EventsPage/OneEventPage.js
@@ -3,7 +3,7 @@ import LoadingCircle from '../../Shared/LoadingCircle'
 import { connect } from 'react-redux'
 import BreadCrumbBar from '../../Shared/BreadCrumbBar'
 import notFound from './not-found.jpg';
-import { dateFormatStringTuple, locationFormatJSX } from '../../Utils';
+import { dateFormatJSXVerbose, locationFormatJSX } from '../../Utils';
 
 class OneEventPage extends React.Component {
 	/**
@@ -35,8 +35,7 @@ class OneEventPage extends React.Component {
 
 	renderEvent(event) {
 		if (!event) return (<div> ...oops couldn't find event with id: {this.props.match.params.id}</div>);
-        let startDate, endDate;
-        [startDate, endDate] = dateFormatStringTuple(new Date(event.start_date_and_time), new Date(event.end_date_and_time));
+        let dateJSX = dateFormatJSXVerbose(new Date(event.start_date_and_time), new Date(event.end_date_and_time));
 		const location = event.location;
 
 		return (
@@ -60,9 +59,7 @@ class OneEventPage extends React.Component {
 											</li> */}
 										<li key='time'><b>Date<br /> </b>
 											<div style={{ paddingLeft: 20 }}>
-                                                <span className="make-me-dark">{startDate}</span><br />
-												<b><span className="text text-success"> TO </span> </b><br />
-												<span className="make-me-dark">{endDate}</span>
+                                                <span className="make-me-dark">{dateJSX}</span>
 											</div>
 										</li>
 										{location ?

--- a/v2.0/src/Components/Pages/HomePage/EventHomepageSection.js
+++ b/v2.0/src/Components/Pages/HomePage/EventHomepageSection.js
@@ -37,7 +37,7 @@ class Events extends React.Component {
         const img = event.image.url ? event.image.url : defaultImg;
         return (
           <article key={index.toString()} className="cursor home-events-hover col-md-4 col-lg-4 col-sm-6 col-xs-12" style={{ marginBottom: 10, marginTop: 10 }} onClick={() => { window.location = this.props.links.events + "/" + event.id }}>
-            <div className="z-depth-1" style={{ borderRadius: 15, height: 415 }}>
+            <div className="z-depth-1" style={{ borderRadius: 15, height: 460 }}>
               <img alt="IMG" src={img} className="home-events-img" />
               <div style={{ padding: 11, paddingLeft: 17, height: 120 }}>
                 <h5 className="zero-margin-btm"><b>{ev_name}</b></h5>
@@ -49,7 +49,7 @@ class Events extends React.Component {
                   :
                   null
                 }
-                <p style={{ fontSize: 14 }} className="text text-success zero-margin-btm">{dateString}</p>
+                <p style={{ fontSize: 13 }} className="text text-success zero-margin-btm">{dateString}</p>
               </div>
             </div>
           </article>

--- a/v2.0/src/components/Utils.js
+++ b/v2.0/src/components/Utils.js
@@ -70,6 +70,31 @@ export function dateFormatStringTuple(startDate, endDate) {
 }
 
 /**
+ * returns a JSX-formatted date which varies depending on the relationship between provided dates
+ * when start and end dates are on different days, it provides a more wordy string than dateFormatString
+ * and includes line breaks
+ * @param startDate 
+ * @param endDate 
+ */
+export function dateFormatJSXVerbose(startDate, endDate) {
+    if (sameDay(startDate, endDate))
+        return (
+            <span>
+                {dateFormatString(startDate, endDate)}
+            </span>
+        );
+
+    let startString, endString;
+    [startString, endString] = dateFormatStringTuple(startDate, endDate);
+    return (
+        <span>
+            {startString} <br /><b>to</b><br /> {endString}
+        </span>
+    );
+
+}
+
+/**
  * returns JSX-formatted version of the provided date
  * @param location
  */


### PR DESCRIPTION
I realized that I hadn't dealt with two of the changes mentioned on ticket #167 :

1. reformatting the word "to" on individual event page
2. if a single day, no "to" on individual event page

These commits make those changes, as well as add a bit of height to the homepage event cards so text doesn't overflow them.

Sorry for overlooking these details in my previous pull request!