### PR TITLE
Welcome images overhaul (resize cropping + carousel)

### DIFF
--- a/v2.0/src/Components/Pages/EventsPage/OneEventPage.js
+++ b/v2.0/src/Components/Pages/EventsPage/OneEventPage.js
@@ -3,7 +3,7 @@ import LoadingCircle from '../../Shared/LoadingCircle'
 import { connect } from 'react-redux'
 import BreadCrumbBar from '../../Shared/BreadCrumbBar'
 import notFound from './not-found.jpg';
-import { dateFormatJSXVerbose, locationFormatJSX } from '../../Utils';
+import { dateFormatString, locationFormatJSX } from '../../Utils';
 
 class OneEventPage extends React.Component {
 	/**
@@ -35,7 +35,7 @@ class OneEventPage extends React.Component {
 
 	renderEvent(event) {
 		if (!event) return (<div> ...oops couldn't find event with id: {this.props.match.params.id}</div>);
-        let dateJSX = dateFormatJSXVerbose(new Date(event.start_date_and_time), new Date(event.end_date_and_time));
+        let dateString = dateFormatString(new Date(event.start_date_and_time), new Date(event.end_date_and_time));
 		const location = event.location;
 
 		return (
@@ -59,7 +59,7 @@ class OneEventPage extends React.Component {
 											</li> */}
 										<li key='time'><b>Date<br /> </b>
 											<div style={{ paddingLeft: 20 }}>
-                                                <span className="make-me-dark">{dateJSX}</span>
+                                                <span className="make-me-dark">{dateString}</span>
 											</div>
 										</li>
 										{location ?

--- a/v2.0/src/Components/Shared/WelcomeImages.js
+++ b/v2.0/src/Components/Shared/WelcomeImages.js
@@ -16,9 +16,7 @@ class WelcomeImages extends React.Component {
     };
 
     render() {
-        var picture1 = this.props.data[0].url;
-        var picture2 = this.props.data[1].url;
-        var picture3 = this.props.data[2].url;
+        var images = this.props.data.map(data => data.url);
 
         var imageStyle = {
             height: '100%',
@@ -35,13 +33,13 @@ class WelcomeImages extends React.Component {
                 gridTemplateColumns: '1fr 1fr 1fr',
                 gridTemplateRows: '1fr'
             }
-            imageStyle["minWidth"] = window.innerWidth / 3 + 'px';
+            imageStyle["minWidth"] = window.innerWidth / images.length + 'px';
 
             return (
                 <div className="inner-banner text-center" style={bannerStyle}>
-                    <img src={picture1} alt="" style={imageStyle} />
-                    <img src={picture2} alt="" style={imageStyle} />
-                    <img src={picture3} alt="" style={imageStyle} />
+                    {images.map(image =>
+                        <img src={image} alt="" style={imageStyle} />)
+                    }
                 </div>
             );
 
@@ -63,27 +61,18 @@ class WelcomeImages extends React.Component {
                         controls={false}
                         pauseOnHover={false}
                     >
-                        <Carousel.Item>
-                            <div style={divStyle}>
-                                <img src={picture2} alt="" style={imageStyle} />
-                            </div>
-                        </Carousel.Item>
-                        <Carousel.Item>
-                            <div style={divStyle}>
-                                <img src={picture1} alt="" style={imageStyle} />
-                            </div>
-                        </Carousel.Item>
-                        <Carousel.Item>
-                            <div style={divStyle}>
-                                <img src={picture3} alt="" style={imageStyle} />
-                            </div>
-                        </Carousel.Item>
+                        {images.map(image => (
+                            <Carousel.Item>
+                                <div style={divStyle}>
+                                    <img src={image} alt="" style={imageStyle} />
+                                </div>
+                            </Carousel.Item>))
+                        }
                     </Carousel>
                 </div>
 
             );
         }
-
     }
 }
 

--- a/v2.0/src/Components/Shared/WelcomeImages.js
+++ b/v2.0/src/Components/Shared/WelcomeImages.js
@@ -15,61 +15,72 @@ class WelcomeImages extends React.Component {
         this.forceUpdate();
     };
 
-    /** TODO:
-     * implement the changes mentioned in ticket #100 for the first case
-     * work on performance and formatting for the second case
-     */
-
     render() {
         var picture1 = this.props.data[0].url;
         var picture2 = this.props.data[1].url;
         var picture3 = this.props.data[2].url;
 
+        var imageStyle = {
+            height: '100%',
+            width: 'auto',
+            objectFit: "cover"
+        }
 
-        if (window.innerWidth > 900) {
-            var bannerstyle = {
-                backgroundImage: `url(${picture1}), url(${picture2}), url(${picture3})`,
-                backgroundSize: "33.333333%",
-                backgroundPosition: "left top, center top, right top"
+        if (window.innerWidth > 700) {
+
+            var bannerStyle = {
+                height: '300px',
+                overflow: 'hidden',
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr 1fr',
+                gridTemplateRows: '1fr'
             }
+            imageStyle["minWidth"] = window.innerWidth / 3 + 'px';
+
             return (
-                <div className="inner-banner text-center" style={bannerstyle}>
-                    <div className="container">
-                        <div className="box"></div>
-                    </div>
+                <div className="inner-banner text-center" style={bannerStyle}>
+                    <img src={picture1} alt="" style={imageStyle} />
+                    <img src={picture2} alt="" style={imageStyle} />
+                    <img src={picture3} alt="" style={imageStyle} />
                 </div>
             );
+
         } else {
+
+            let divStyle = {
+                height: '300px',
+                display: 'block',
+            };
+            imageStyle["minWidth"] = window.innerWidth + 'px';
+
             return (
-                <div className="inner-banner text-center">
-                    <div className="container">
-                        <div className="box">
-                            <Carousel
-                                interval={3000}
-                                fade
-                                indicators={false}
-                                controls={false}
-                                pauseOnHover={false}
-                            >
-                                <Carousel.Item>
-                                    <div style={{ height: '250px' }} >
-                                        <img src={picture1} alt="" />
-                                    </div>
-                                </Carousel.Item>
-                                <Carousel.Item>
-                                    <div style={{ height: '250px' }}>
-                                        <img src={picture2} alt="" />
-                                    </div>
-                                </Carousel.Item>
-                                <Carousel.Item>
-                                    <div style={{ height: '250px' }}>
-                                        <img src={picture3} alt="" />
-                                    </div>
-                                </Carousel.Item>
-                            </Carousel>
-                        </div>
-                    </div>
+                <div className="inner-banner text-center" >
+
+                    <Carousel
+                        interval={3000}
+                        fade
+                        indicators={false}
+                        controls={false}
+                        pauseOnHover={false}
+                    >
+                        <Carousel.Item>
+                            <div style={divStyle}>
+                                <img src={picture2} alt="" style={imageStyle} />
+                            </div>
+                        </Carousel.Item>
+                        <Carousel.Item>
+                            <div style={divStyle}>
+                                <img src={picture1} alt="" style={imageStyle} />
+                            </div>
+                        </Carousel.Item>
+                        <Carousel.Item>
+                            <div style={divStyle}>
+                                <img src={picture3} alt="" style={imageStyle} />
+                            </div>
+                        </Carousel.Item>
+                    </Carousel>
                 </div>
+
             );
         }
 

--- a/v2.0/src/Components/Shared/WelcomeImages.js
+++ b/v2.0/src/Components/Shared/WelcomeImages.js
@@ -1,55 +1,81 @@
 import React from 'react'
+import Carousel from 'react-bootstrap/Carousel'
 
 /** Renders an image banner that has one, two or three images across it based on screen size
  */
 class WelcomeImages extends React.Component {
-	componentDidMount() {
-		window.addEventListener('resize', this.handleResize);
-	}
-	componentWillUnmount() {
-		window.removeEventListener('resize', this.handleResize);
-	}
-	handleResize = () => {
-		this.forceUpdate();
-	};
+    componentDidMount() {
+        window.addEventListener('resize', this.handleResize);
+    }
+    componentWillUnmount() {
+        window.removeEventListener('resize', this.handleResize);
+    }
+    handleResize = () => {
+        this.forceUpdate();
+    };
 
-	render() {
-		//works best with tall images from online, my images are too big(2-5mb) so they slow it down but these are good
-		var picture1 = this.props.data[0].url;
-		var picture2 = this.props.data[1].url;
-		var picture3 = this.props.data[2].url;
 
-		var bannerstyle; //checks the width and changes how many images are displayed based on that
-		if (window.innerWidth > 1100) {
-			bannerstyle = {
-				backgroundImage: `url(${picture1}), url(${picture2}), url(${picture3})`,
-				backgroundSize: "33.333333%",
-				backgroundPosition: "left top, center top, right top"
-			}
-		} else if (window.innerWidth > 750) {
-			bannerstyle = {
-				backgroundImage: `url(${picture1}), url(${picture2})`,
-				backgroundSize: "50%",
-				backgroundPosition: "left top, right top"
-			}
-		} else {
-			bannerstyle = {
-				backgroundImage: `url(${picture1})`,
-				backgroundSize: "cover",
-				backgroundPosition: "left top"
-			}
-		}
-		//TODO make this only one or only two images depending on screen size.
-		return (
-			<div className="inner-banner text-center" style={bannerstyle}>
-				<div className="container">
-					<div className="box">
-						{/* <h1>{this.props.title}</h1> */}
-					</div>
-				</div>
-			</div>
-		);
-	}
+    /** TODO:
+     * implement the changes mentioned in ticket #100 for the first case
+     * work on performance and formatting for the second case
+     */
+
+    render() {
+        var picture1 = this.props.data[0].url;
+        var picture2 = this.props.data[1].url;
+        var picture3 = this.props.data[2].url;
+
+
+        if (window.innerWidth > 900) {
+            var bannerstyle = {
+                backgroundImage: `url(${picture1}), url(${picture2}), url(${picture3})`,
+                backgroundSize: "33.333333%",
+                backgroundPosition: "left top, center top, right top"
+            }
+            return (
+                <div className="inner-banner text-center" style={bannerstyle}>
+                    <div className="container">
+                        <div className="box">
+                            {/* <h1>{this.props.title}</h1> */}
+                        </div>
+                    </div>
+                </div>
+            );
+        } else {
+            return (
+                <div className="inner-banner text-center">
+                    <div className="container">
+                        <div className="box">
+                            <Carousel
+                                interval={3000}
+                                fade
+                                indicators={false}
+                                controls={false}
+                                pauseOnHover={false}
+                            >
+                                <Carousel.Item>
+                                    <div style={{ height: '250px' }} >
+                                        <img src={picture1} alt="" />
+                                    </div>
+                                </Carousel.Item>
+                                <Carousel.Item>
+                                    <div style={{ height: '250px' }}>
+                                        <img src={picture2} alt="" />
+                                    </div>
+                                </Carousel.Item>
+                                <Carousel.Item>
+                                    <div style={{ height: '250px' }}>
+                                        <img src={picture3} alt="" />
+                                    </div>
+                                </Carousel.Item>
+                            </Carousel>
+                        </div>
+                    </div>
+                </div>
+            );
+        }
+
+    }
 }
 
 

--- a/v2.0/src/Components/Shared/WelcomeImages.js
+++ b/v2.0/src/Components/Shared/WelcomeImages.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import Carousel from 'react-bootstrap/Carousel'
 
-/** Renders an image banner that has one, two or three images across it based on screen size
+/** Renders an image banner that is either three images wide, or a carousel of three images
+ * depending on the window width
  */
 class WelcomeImages extends React.Component {
     componentDidMount() {
@@ -13,7 +14,6 @@ class WelcomeImages extends React.Component {
     handleResize = () => {
         this.forceUpdate();
     };
-
 
     /** TODO:
      * implement the changes mentioned in ticket #100 for the first case
@@ -35,9 +35,7 @@ class WelcomeImages extends React.Component {
             return (
                 <div className="inner-banner text-center" style={bannerstyle}>
                     <div className="container">
-                        <div className="box">
-                            {/* <h1>{this.props.title}</h1> */}
-                        </div>
+                        <div className="box"></div>
                     </div>
                 </div>
             );

--- a/v2.0/src/Components/Shared/WelcomeImages.js
+++ b/v2.0/src/Components/Shared/WelcomeImages.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import Carousel from 'react-bootstrap/Carousel'
 
-/** Renders an image banner that is either three images wide, or a carousel of three images
- * depending on the window width
+/** Renders an arbititary amount of images beside eachother, until the window is skinny enough
+ * at which point renders a carousel that cycles all of the images
  */
 class WelcomeImages extends React.Component {
     componentDidMount() {
@@ -75,6 +75,5 @@ class WelcomeImages extends React.Component {
         }
     }
 }
-
 
 export default WelcomeImages;

--- a/v2.0/src/components/Utils.js
+++ b/v2.0/src/components/Utils.js
@@ -58,41 +58,6 @@ export function dateFormatString(startDate, endDate) {
     return dateString;
 }
 
-/**
- * returns a two-tuple (length-two array) containing formatted strings for the provided dates
- * for easy use in cases where the dates are used as seperate strings
- * @param startDate 
- * @param endDate 
- */
-export function dateFormatStringTuple(startDate, endDate) {
-    const format = "MMMM Do YYYY, h:mm a";
-    return [moment(startDate).format(format), moment(endDate).format(format)];
-}
-
-/**
- * returns a JSX-formatted date which varies depending on the relationship between provided dates
- * when start and end dates are on different days, it provides a more wordy string than dateFormatString
- * and includes line breaks
- * @param startDate 
- * @param endDate 
- */
-export function dateFormatJSXVerbose(startDate, endDate) {
-    if (sameDay(startDate, endDate))
-        return (
-            <span>
-                {dateFormatString(startDate, endDate)}
-            </span>
-        );
-
-    let startString, endString;
-    [startString, endString] = dateFormatStringTuple(startDate, endDate);
-    return (
-        <span>
-            {startString} <br /><b>to</b><br /> {endString}
-        </span>
-    );
-
-}
 
 /**
  * returns JSX-formatted version of the provided date


### PR DESCRIPTION
changed the way that that the welcome images crop as the window is resized - heights remain fixed while the width of images adjusts. (ticket #100 )

when the window is skinny enough, instead of removing some of the images, now an image carousel that cycles between the three will display. (ticket #101 )

the welcome images component now accepts an arbitrary number of images, which makes it much more flexible for communities

also included in this PR is (hopefully) the last tweak I'll be making to date formatting