### PR TITLE
Revert 238 temp teams sort change

### DIFF
--- a/v2.0/src/Components/Pages/TeamsPage/TeamsPage.js
+++ b/v2.0/src/Components/Pages/TeamsPage/TeamsPage.js
@@ -336,13 +336,9 @@ class TeamsPage extends React.Component {
       teamsSorted[i]["avrgActionsPerMember"] = avrg;
     }
 
-    //AD-HOC! This is for demo-ing JCAN so "Congregation Beth El" shows up first
     teamsSorted = teamsSorted.sort((a, b) => {
-      if (a.team.name.toLowerCase() > b.team.name.toLowerCase()) return -1;
-      if (a.team.name.toLowerCase() < b.team.name.toLowerCase()) return 1;
-      return 0;
+      return b.avrgActionsPerMember - a.avrgActionsPerMember;
     });
-
 
     //"force-listen" to the user requested sort
     teamsSorted = this.state.sorted_Teams

--- a/v2.0/src/Components/Pages/TeamsPage/TeamsPage.js
+++ b/v2.0/src/Components/Pages/TeamsPage/TeamsPage.js
@@ -336,10 +336,6 @@ class TeamsPage extends React.Component {
       teamsSorted[i]["avrgActionsPerMember"] = avrg;
     }
 
-    teamsSorted = teamsSorted.sort((a, b) => {
-      return b.avrgActionsPerMember - a.avrgActionsPerMember;
-    });
-
     //"force-listen" to the user requested sort
     teamsSorted = this.state.sorted_Teams
       ? this.state.sorted_Teams


### PR DESCRIPTION
Ellen said she is OK with using A-Z teams sorting for the time being. This change achieves this, as the data comes from the API sorted. Sorry for all the confusion