### PR TITLE
add is_dev tag to team actions call so context is correctly set on the API

### DIFF
--- a/v2.0/src/components/Pages/TeamsPage/TeamActionsGraph.js
+++ b/v2.0/src/components/Pages/TeamsPage/TeamActionsGraph.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Bar } from "react-chartjs-2";
 import { apiCall } from "../../../api/functions";
+import { IS_PROD } from '../../../config/config'
 
 class TeamActionsGraph extends React.Component {
 
@@ -13,7 +14,7 @@ class TeamActionsGraph extends React.Component {
   }
 
   fetch(id) {
-    apiCall('graphs.actions.completed.byTeam', { team_id: id }).then(json => {
+    apiCall('graphs.actions.completed.byTeam', { team_id: id, is_dev: !IS_PROD }).then(json => {
       if (json.success)
         this.setState({ graphResponse: json.data, loading: false });
     }).catch(err => {


### PR DESCRIPTION
[Here](https://github.com/massenergize/api/blob/8acb3826167ee258213131230b68ef1495f6a0d9/src/_main_/utils/context/__init__.py#L51), the backend was erroneously treating our calls to `graphs.actions.completed.byTeam` as if they were coming from prod when they were really coming from dev, because when no dev/prod context is provided, it defaults to prod. This was causing it to send back a permissions error for that route. This PR fixes that by simply including the dev/prod boolean from the front-end API call.