### PR TITLE
changes to profile page teams section & small error page fixes

### DIFF
--- a/v2.0/src/Components/Pages/HomePage/HomePage.js
+++ b/v2.0/src/Components/Pages/HomePage/HomePage.js
@@ -13,7 +13,8 @@ class HomePage extends React.Component {
   render() {
     if (!this.props.pageData) {
       return <ErrorPage
-        errorMessage="Could not load this Community"
+        errorMessage="Unable to load this Community"
+        invalidCommunity
       />
     }
     const comGoals = this.props.pageData ? this.props.pageData.goal : null;

--- a/v2.0/src/Components/Pages/ProfilePage/ProfilePage.js
+++ b/v2.0/src/Components/Pages/ProfilePage/ProfilePage.js
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import { Link, Redirect } from "react-router-dom";
 import URLS from "../../../api/urls";
 import { apiCall, postJson } from "../../../api/functions";
-
+import LoadingCircle from "../../Shared/LoadingCircle";
 import Cart from "../../Shared/Cart";
 import BreadCrumbBar from "../../Shared/BreadCrumbBar";
 import Counter from "./Counter";
@@ -75,6 +75,10 @@ class ProfilePage extends React.Component {
     }
     const myHouseholds = this.props.user.households || [];
     const myCommunities = this.props.user.communities || [];
+
+    if (!this.props.teamsPage) {
+      return <LoadingCircle />;
+    }
 
     if (myHouseholds.length === 0 && !this.state.addedHouse) {
       this.setState({ addedHouse: true });
@@ -222,7 +226,7 @@ class ProfilePage extends React.Component {
                   <table className="profile-table" style={{ width: "100%" }}>
                     <tbody>
                       <tr>
-                        <th> Your teams </th>
+                        <th> Your Teams </th>
                         <th></th>
                       </tr>
                       {this.renderTeams(user.teams)}
@@ -233,9 +237,7 @@ class ProfilePage extends React.Component {
                             to={this.props.links.teams}
                             style={{ margin: "5px" }}
                           >
-                            {this.props.user.teams.length > 0
-                              ? "Join another Team"
-                              : "Join a Team!"}
+                            View all Teams
                           </Link>
                         </td>
                       </tr>
@@ -532,28 +534,32 @@ class ProfilePage extends React.Component {
   }
   renderTeams(teams) {
     if (!teams) return null;
+
+    const currentCommunityTeamIDs = this.props.teamsPage && this.props.teamsPage.map(teamStats => teamStats.team.id);
+    const inThisCommunity = (team) => ( currentCommunityTeamIDs && currentCommunityTeamIDs.includes(team.id)) ;
+
     return Object.keys(teams).map((key) => {
       const team = teams[key];
       return (
         <tr key={key}>
           <td>
-            {team.name} &nbsp;
-            <Tooltip title={team.name} text={team.description} dir="right">
-              <span
-                className="fa fa-info-circle"
-                style={{ color: "#428a36" }}
-              ></span>
-            </Tooltip>
+            <h5>{team.name}</h5>
+            {team.description && <p style={{ fontSize: '14px', margin: 0 }}>
+              {team.description.length > 70 ?
+                 team.description.substring(0, 70) + "..."
+                 : team.description}
+            </p>}
           </td>
-          <td>
-            {" "}
-            <button className="remove-btn">
-              {" "}
-              <i
-                className="fa fa-trash"
-                onClick={() => this.leaveTeam(team)}
-              ></i>
-            </button>{" "}
+          <td align="center">
+            {inThisCommunity(team) ?
+              <Link to={`${this.props.links.teams + "/" + team.id} `}>
+                <button className="btn round-me join-team-btn raise">
+                  View
+                </button>
+              </Link>
+              :
+              <p style={{fontSize:'14px', margin: 0}}>Team is in a <br/> different community.</p>
+          }
           </td>
         </tr>
       );
@@ -737,33 +743,6 @@ class ProfilePage extends React.Component {
     }
   };
 
-  leaveTeam = (team) => {
-    if (team && this.props.user) {
-      const body = {
-        user_id: this.props.user.id,
-        team_id: team.id,
-      };
-      apiCall("teams.join", body)
-        .then((json) => {
-          if (json.success) {
-            this.props.reduxLeaveTeam(team);
-            this.props.reduxRemoveTeamMember({
-              team: team,
-              member: {
-                households: this.props.user.households.length,
-                actions: this.props.todo.length + this.props.done.length,
-                actions_completed: this.props.done.length,
-                actions_todo: this.props.todo.length,
-              },
-            });
-          }
-        })
-        .catch((error) => {
-          console.log(error);
-        });
-    }
-  };
-
   clearError = () => {
     if (this.state.deletingHHError) {
       this.setState({
@@ -826,6 +805,7 @@ const mapStoreToProps = (store) => {
     user: store.user.info,
     todo: store.user.todo,
     done: store.user.done,
+    teamsPage: store.page.teamsPage,
     communities: store.user.info ? store.user.info.communities : null,
     community: store.page.community,
     communityData: store.page.communityData,

--- a/v2.0/src/Components/Pages/ProfilePage/ProfilePage.js
+++ b/v2.0/src/Components/Pages/ProfilePage/ProfilePage.js
@@ -226,12 +226,11 @@ class ProfilePage extends React.Component {
                   <table className="profile-table" style={{ width: "100%" }}>
                     <tbody>
                       <tr>
-                        <th> Your Teams </th>
-                        <th></th>
+                        <th> Your Teams <small>(* outside this community)</small> </th>
                       </tr>
                       {this.renderTeams(user.teams)}
                       <tr>
-                        <td colSpan={2} align="center">
+                        <td  align="center">
                           <Link
                             className="thm-btn btn-finishing"
                             to={this.props.links.teams}
@@ -540,26 +539,24 @@ class ProfilePage extends React.Component {
 
     return Object.keys(teams).map((key) => {
       const team = teams[key];
+
       return (
         <tr key={key}>
           <td>
-            <h5>{team.name}</h5>
-            {team.description && <p style={{ fontSize: '14px', margin: 0 }}>
-              {team.description.length > 70 ?
-                 team.description.substring(0, 70) + "..."
-                 : team.description}
-            </p>}
-          </td>
-          <td align="center">
             {inThisCommunity(team) ?
-              <Link to={`${this.props.links.teams + "/" + team.id} `}>
-                <button className="btn round-me join-team-btn raise">
-                  View
-                </button>
-              </Link>
+              <Link to={`${this.props.links.teams + "/" + team.id} `}><h6>{team.name}</h6></Link>
               :
-              <p style={{fontSize:'14px', margin: 0}}>Team is in a <br/> different community.</p>
-          }
+              <>
+                <h6>{team.name}*</h6>
+              </>
+            }
+            {team.description &&
+              <p style={{ fontSize: '12px', margin: 0 }}>
+                {team.description.length > 70 ?
+                  team.description.substring(0, 70) + "..."
+                  : team.description}
+              </p>
+            }
           </td>
         </tr>
       );

--- a/v2.0/src/components/Pages/Errors/ErrorPage.js
+++ b/v2.0/src/components/Pages/Errors/ErrorPage.js
@@ -24,10 +24,13 @@ class ErrorPage extends React.Component {
             <img alt="404" src={oops} style={{ marginBottom: 20, height: 100, width: 100 }} />
             <h1 style={{ color: 'lightgray' }}>{errorMessage}</h1>
             <h3 className='text-center' style={{ marginBottom: 20, color: 'lightgray' }}> {errorDescription}</h3>
-            <p className='text-center'>
-              <Link to={this.props.links.home} className="mass-domain-link ">
-                Return to Home Page
-              </Link> </p>
+            {!this.props.invalidCommunity &&
+              <p className='text-center'>
+                <Link to={this.props.links.home} className="mass-domain-link ">
+                  Return to Home Page
+                </Link>
+              </p>
+            }
           </center>
 
         </div>


### PR DESCRIPTION
please run locally and let me know what you think of my design here

unfortunately, there was no simple way to add a community link on out-of-community teams' rows, as the `users.info` API call from which we get those teams does not contain their communities. all I can do is detect when one of those teams is _not_ in the current community, by seeing if their ID is in the IDs of the `teams.stats` call in the redux store. so, to detect which specific other community these teams belong to would require writing in more API calls, which seems like overkill if we are planning a larger redesign of the profile page in the long term.