### PR TITLE
Issue 373 - image on team and action shares

### DIFF
--- a/v2.0/public/index.html
+++ b/v2.0/public/index.html
@@ -26,13 +26,13 @@
     <meta name="theme-color" content="#000000" />
 
     <meta property="og:title" content="MassEnergize" />
-    <meta property="og:image" content="https://massenergize.org/wp-content/uploads/2019/08/GENERAL2019.jpg" />
+    <meta property="og:image" content="https://massenergize.org/wp-content/uploads/2020/10/ME-favicon.png" />
     <meta property="og:description" content="Supporting community action on climate change" />
 
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:title" content="MassEnergize">
     <meta property="twitter:description" content="Supporting community action on climate change">
-    <meta property="twitter:image" content="https://massenergize.org/wp-content/uploads/2019/08/GENERAL2019.jpg">
+    <meta property="twitter:image" content="https://massenergize.org/wp-content/uploads/2020/10/ME-favicon.png">
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
    

--- a/v2.0/src/Components/Pages/TeamsPage/TeamInfoModal.js
+++ b/v2.0/src/Components/Pages/TeamsPage/TeamInfoModal.js
@@ -67,7 +67,7 @@ class TeamInfoModal extends React.Component {
         name: "tagline",
         type: "input",
         label: "Tagline*",
-        placeholder: "A catchy slogan for you team...",
+        placeholder: "A catchy slogan for your team...",
         value: team && team.tagline,
       },
       !team && {


### PR DESCRIPTION
The image used on facebook or twitter posts was the long thin ME logo.  I changed it to be the Favicon which is squre.  See whether you like it.