### PR TITLE
Change FilterBox With URL 

### DIFF
--- a/v2.0/src/AppRouter.js
+++ b/v2.0/src/AppRouter.js
@@ -136,7 +136,7 @@ class AppRouter extends Component {
       apiCall("events.list", body),
       apiCall("impact_page_settings.info", body),
       apiCall("policies.list", body),
-      apiCall("teams_page_settings.info", body),     
+      apiCall("teams_page_settings.info", body),
       apiCall("teams.stats", body),
       apiCall("tag_collections.list", body),
       apiCall("testimonials.list", body),
@@ -385,14 +385,44 @@ class AppRouter extends Component {
               />
               <Route exact path={links.home} component={HomePage} />
               <Route exact path={`${links.home}/home`} component={HomePage} />
+              {/* ----------------------------- DEMO ROUTES ---------------------------------- */}
+              <Route
+                exact
+                path={`${links.actions}-demo/filter/:type`}
+                component={ActionsPage}
+              />
+              <Route
+                exact
+                path={`${links.services}-demo/filter/:type`}
+                component={ServicesPage}
+              />
+
+              <Route
+                exact
+                path={`${links.testimonials}-demo/filter/:type`}
+                component={StoriesPage}
+              />
+              <Route
+                exact
+                path={`${links.events}-demo/filter/:type`}
+                component={EventsPage}
+              />
+
+              {/* ------------------------------------------------------------------------------- */}
               <Route exact path={links.actions} component={ActionsPage} />
+              <Route
+                exact
+                path={`${links.actions}/:id`}
+                component={OneActionPage}
+              />
+
               <Route path={links.aboutus} component={AboutUsPage} />
               <Route exact path={links.services} component={ServicesPage} />
               <Route
                 path={`${links.services}/:id`}
                 component={OneServicePage}
               />
-              <Route path={`${links.actions}/:id`} component={OneActionPage} />
+
               <Route exact path={links.testimonials} component={StoriesPage} />
               <Route
                 path={`${links.testimonials}/:id`}

--- a/v2.0/src/AppRouter.js
+++ b/v2.0/src/AppRouter.js
@@ -378,37 +378,13 @@ class AppRouter extends Component {
             </Switch>
           ) : (
             <Switch>
-              {/* ---- This route is a facebook app requirement. */}
+              {/* ---- This route is a facebook app requirement. -------- */}
               <Route
                 path={`/${subdomain}/how-to-delete-my-data`}
                 component={Help}
               />
               <Route exact path={links.home} component={HomePage} />
               <Route exact path={`${links.home}/home`} component={HomePage} />
-              {/* ----------------------------- DEMO ROUTES ---------------------------------- */}
-              <Route
-                exact
-                path={`${links.actions}-demo/filter/:type`}
-                component={ActionsPage}
-              />
-              <Route
-                exact
-                path={`${links.services}-demo/filter/:type`}
-                component={ServicesPage}
-              />
-
-              <Route
-                exact
-                path={`${links.testimonials}-demo/filter/:type`}
-                component={StoriesPage}
-              />
-              <Route
-                exact
-                path={`${links.events}-demo/filter/:type`}
-                component={EventsPage}
-              />
-
-              {/* ------------------------------------------------------------------------------- */}
               <Route exact path={links.actions} component={ActionsPage} />
               <Route
                 exact

--- a/v2.0/src/Components/Pages/ActionsPage/ActionBoxCounter.js
+++ b/v2.0/src/Components/Pages/ActionsPage/ActionBoxCounter.js
@@ -26,7 +26,12 @@ export default class ActionBoxCounter extends Component {
             <CountUp
               end={sumOfCarbonScores(data)}
               duration={2}
-              style={{ fontWeight: "600", margin: 10, fontSize: 26 }}
+              style={{
+                fontWeight: "600",
+                margin: 10,
+                fontSize: 26,
+                color: "black",
+              }}
             />
             <br />
             <i className="fa fa-tree box-ico"></i>{" "}

--- a/v2.0/src/Components/Pages/ActionsPage/ActionsPage.js
+++ b/v2.0/src/Components/Pages/ActionsPage/ActionsPage.js
@@ -163,6 +163,8 @@ class ActionsPage extends React.Component {
         action.deep_dive.toLowerCase().includes(word)
     );
   }
+
+  
   getContentToDisplay() {
     const { mirror_actions, actions } = this.state; // items from when user is typing in search box
     const propActions = this.props.actions;

--- a/v2.0/src/Components/Pages/ActionsPage/ActionsPage.js
+++ b/v2.0/src/Components/Pages/ActionsPage/ActionsPage.js
@@ -108,7 +108,6 @@ class ActionsPage extends React.Component {
     return common;
   }
 
-
   renderModal() {
     if (this.state.openModalForm) {
       return (
@@ -178,16 +177,14 @@ class ActionsPage extends React.Component {
     return actions;
   }
   render() {
-
     const pageData = this.props.pageData;
-    console.log(pageData);
-		if (pageData == null) return <LoadingCircle />
-    
+    if (pageData == null) return <LoadingCircle />;
+
     if (!this.props.actions) {
       return <LoadingCircle />;
     }
 
-    const title = pageData && pageData.title ? pageData.title : 'Actions'
+    const title = pageData && pageData.title ? pageData.title : "Actions";
     //const sub_title = pageData && pageData.sub_title ? pageData.sub_title : 'Let us know what you have already done, and pledge to do more for impact'
     const description = pageData.description ? pageData.description : null;
 
@@ -259,36 +256,30 @@ class ActionsPage extends React.Component {
                     tagCols={this.props.tagCols}
                     boxClick={this.addMeToSelected}
                     search={this.handleSearch}
-                    version={2}
                   />
                   <div className="text-center">
-                  {description ? (
-                    <Tooltip
-                      text={description}
-                      paperStyle={{ maxWidth: "100vh" }}
-                    >
-                   <PageTitle style={{ fontSize: 24 }}>
-                    {title}
-                    <span
-                    className="fa fa-info-circle"
-                    style={{ color: "#428a36", padding: "5px" }}
-                  ></span>
-
-                  </PageTitle>
-                  </Tooltip>
-                  ) : (
-                    <PageTitle style={{ fontSize: 24 }}>
-                    {title}
-                  </PageTitle>
-                  )}
+                    {description ? (
+                      <Tooltip
+                        text={description}
+                        paperStyle={{ maxWidth: "100vh" }}
+                      >
+                        <PageTitle style={{ fontSize: 24 }}>
+                          {title}
+                          <span
+                            className="fa fa-info-circle"
+                            style={{ color: "#428a36", padding: "5px" }}
+                          ></span>
+                        </PageTitle>
+                      </Tooltip>
+                    ) : (
+                      <PageTitle style={{ fontSize: 24 }}>{title}</PageTitle>
+                    )}
                   </div>
                   <center>
-						        {
-							        pageData.sub_title ? 
-							        <small>{pageData.sub_title}</small>
-							        :null
-						        }
-						      </center>
+                    {pageData.sub_title ? (
+                      <small>{pageData.sub_title}</small>
+                    ) : null}
+                  </center>
 
                   <div
                     className="row"
@@ -521,7 +512,6 @@ class ActionsPage extends React.Component {
   }
 }
 const mapStoreToProps = (store) => {
-  console.log(store.page);
   return {
     homePageData: store.page.homePage,
     auth: store.firebase.auth,

--- a/v2.0/src/Components/Pages/EventsPage/HorizontalFilterBox.js
+++ b/v2.0/src/Components/Pages/EventsPage/HorizontalFilterBox.js
@@ -5,6 +5,10 @@ import { withRouter } from "react-router";
 import { getPropsArrayFromJsonArray } from "../../Utils";
 import MELightDropDown, { NONE } from "../Widgets/MELightDropDown";
 import METextField from "../Widgets/METextField";
+export const FILTER_BAR_VERSION = "filter_bar_version";
+// const OPTION1 = "option1";
+const OPTION2 = "option2";
+
 class HorizontalFilterBox extends Component {
   constructor() {
     super();
@@ -61,8 +65,7 @@ class HorizontalFilterBox extends Component {
   }
 
   renderTagComponent = () => {
-    var { version } = this.props;
-    version = this.getVersionToShow() || version;
+    const version = this.getVersionToShow();
 
     if (!version || version !== 2) return <></>;
     return (
@@ -135,8 +138,7 @@ class HorizontalFilterBox extends Component {
   }
 
   renderIcon(selected) {
-    var { version } = this.props;
-    version = this.getVersionToShow() || version;
+    const version = this.getVersionToShow();
     if (version && version === 2)
       return <i className=" fa fa-angle-down" style={{ marginLeft: 5 }}></i>;
     if (selected && selected.value)
@@ -156,11 +158,9 @@ class HorizontalFilterBox extends Component {
   }
 
   getVersionToShow() {
-    const { match } = this.props;
-    const params = match && match.params;
-    const type = params && params.type;
-    return type && type.toLowerCase() === "bubble" ? 2 : 1;
-   
+    const version = sessionStorage.getItem(FILTER_BAR_VERSION);
+    if (version === OPTION2) return 2;
+    return 1;
   }
   render() {
     return (
@@ -198,6 +198,5 @@ const mapStoreToProps = (store) => {
 HorizontalFilterBox.defaultProps = {
   version: 1,
 };
-
 
 export default withRouter(connect(mapStoreToProps)(HorizontalFilterBox));

--- a/v2.0/src/Components/Pages/EventsPage/HorizontalFilterBox.js
+++ b/v2.0/src/Components/Pages/EventsPage/HorizontalFilterBox.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { connect } from "react-redux";
+import { withRouter } from "react-router";
 // import MECheckBoxGroup from "../Widgets/MECheckBoxGroup";
 import { getPropsArrayFromJsonArray } from "../../Utils";
 import MELightDropDown, { NONE } from "../Widgets/MELightDropDown";
@@ -60,7 +61,9 @@ class HorizontalFilterBox extends Component {
   }
 
   renderTagComponent = () => {
-    const { version } = this.props;
+    var { version } = this.props;
+    version = this.getVersionToShow() || version;
+
     if (!version || version !== 2) return <></>;
     return (
       <div style={{ padding: 10, background: "#fffbf1" }}>
@@ -75,7 +78,8 @@ class HorizontalFilterBox extends Component {
   };
 
   renderDifferentCollections = () => {
-    const { version } = this.props;
+    var { version } = this.props;
+    version = this.getVersionToShow() || version;
     const col = this.getCollectionSetAccordingToPage();
     if (col) {
       return col.map((set, index) => {
@@ -131,7 +135,8 @@ class HorizontalFilterBox extends Component {
   }
 
   renderIcon(selected) {
-    const { version } = this.props;
+    var { version } = this.props;
+    version = this.getVersionToShow() || version;
     if (version && version === 2)
       return <i className=" fa fa-angle-down" style={{ marginLeft: 5 }}></i>;
     if (selected && selected.value)
@@ -148,6 +153,14 @@ class HorizontalFilterBox extends Component {
         </span>
       );
     return <i className=" fa fa-angle-down" style={{ marginLeft: 5 }}></i>;
+  }
+
+  getVersionToShow() {
+    const { match } = this.props;
+    const params = match && match.params;
+    const type = params && params.type;
+    return type && type.toLowerCase() === "bubble" ? 2 : 1;
+   
   }
   render() {
     return (
@@ -186,4 +199,5 @@ HorizontalFilterBox.defaultProps = {
   version: 1,
 };
 
-export default connect(mapStoreToProps)(HorizontalFilterBox);
+
+export default withRouter(connect(mapStoreToProps)(HorizontalFilterBox));

--- a/v2.0/src/Components/Pages/HomePage/HomePage.js
+++ b/v2.0/src/Components/Pages/HomePage/HomePage.js
@@ -7,11 +7,18 @@ import Events from "./EventHomepageSection";
 import Tooltip from "../Widgets/CustomTooltip";
 import { connect } from "react-redux";
 import { IS_SANDBOX } from "../../../config";
+import { getFilterVersionFromURL } from "../../Utils";
+import { FILTER_BAR_VERSION } from "../EventsPage/HorizontalFilterBox";
 
-/*
+/*'
  * The Home Page of the MassEnergize
  */
 class HomePage extends React.Component {
+  componentDidMount() {
+    const version = getFilterVersionFromURL(this.props.location);
+    if (version) window.sessionStorage.setItem(FILTER_BAR_VERSION, version);
+  }
+
   render() {
     if (!this.props.pageData) {
       return (

--- a/v2.0/src/components/Utils.js
+++ b/v2.0/src/components/Utils.js
@@ -1,16 +1,20 @@
 import * as moment from "moment";
 import React from "react";
 
-export const searchIsActiveFindContent = (
-  data,
-  activeFilters,
-  word,
-  func
-) => {
+export const getFilterVersionFromURL = (location, paramName) => {
+  if (!location || !location.search) return "";
+  const search = location.search;
+  var broken = search.slice(1, search.length);
+  broken = broken.split("=");
+  var found = broken.filter((item) => item.toLowerCase() === "filter")[0];
+  if (!found) return "";
+  return broken[broken.indexOf(found) + 1];
+};
+
+export const searchIsActiveFindContent = (data, activeFilters, word, func) => {
   if (!word) return null;
   word = word.toLowerCase();
-  const content =
-    applyTagsAndGetContent(data, activeFilters) || data;
+  const content = applyTagsAndGetContent(data, activeFilters) || data;
   if (!func) return null;
   return content.filter((action) => func(action, word));
 };

--- a/v2.0/src/config/config.json
+++ b/v2.0/src/config/config.json
@@ -1,5 +1,5 @@
 {
-  "IS_LOCAL": false,
+  "IS_LOCAL": true,
   "IS_PROD": false,
   "IS_CANARY": false,
   "IS_SANDBOX": false,


### PR DESCRIPTION
Filterbox now changes version with  **URL**
The default version of the horizontal filter box is the one that doesnt use bubbles. So, our everyday-routes will use the bar with no-bubbles.
To active the bubble version in any community, use the following URLS

`wayland/actions-demo/filter/bubble`
`wayland/events-demo/filter/bubble`
`wayland/stories-demo/filter/bubble`
`wayland/services-demo/filter/bubble`

**NB: It works for all communities, "wayland" could be any community**