### PR TITLE
"verify email" was just showing on registration page onload. - fixed.

### DIFF
--- a/src/components/Pages/RegisterPage/RegisterPage.js
+++ b/src/components/Pages/RegisterPage/RegisterPage.js
@@ -19,7 +19,7 @@ class RegisterPage extends React.Component {
               <div className="row">
                 {/* <!--Form Column--> */}
                 <div className="form-column column col-md-8 col-12 offset-md-2">
-                  {!auth?.emailVerified && (
+                  {!auth?.isEmpty && !auth?.emailVerified && (
                     <p
                       style={{
                         fontWeight: "bold",


### PR DESCRIPTION
"NB: verify email"  just used to show bare on registration page even when the user hadnt done anything. Now the if case works properly.