### PR TITLE
Added behavior to account for when CO2 graph exists

### DIFF
--- a/src/components/Pages/ActionsPage/OneActionPage.js
+++ b/src/components/Pages/ActionsPage/OneActionPage.js
@@ -464,7 +464,6 @@ class OneActionPage extends React.Component {
       ? community.id === action.community.id
       : true;
     const actionStateCase = this.getActionStateCase();
-
     const seen_tour = window.localStorage.getItem("seen_community_portal_tour");
     const steps = [
       {

--- a/src/components/Pages/ImpactPage/ImpactPage.js
+++ b/src/components/Pages/ImpactPage/ImpactPage.js
@@ -286,16 +286,20 @@ class ImpactPage extends React.Component {
           "Add your household actions to your community’s positive impact!",
         locale: {
           skip: <span>Skip Tour</span>,
-          next: (
-            <Link style={{ color: "white" }} to={this.props.links.teams}>
-              Got it!
-            </Link>
-          ),
+          next:
+            goal && goal.target_carbon_footprint_reduction > 0 ? (
+              <span>Got it!</span>
+            ) : (
+              <Link style={{ color: "white" }} to={this.props.links.teams}>
+                Got it!
+              </Link>
+            ),
         },
         placement: "auto",
-        spotlightClicks: true,
+        spotlightClicks: false,
         disableBeacon: true,
         hideFooter: false,
+        disableScrolling: false,
       },
       {
         target: "#carbon-card",
@@ -313,7 +317,7 @@ class ImpactPage extends React.Component {
           ),
         },
         placement: "auto",
-        spotlightClicks: true,
+        spotlightClicks: false,
         disableBeacon: true,
         hideFooter: false,
       },


### PR DESCRIPTION
If the impact page shows CO2 graph, two steps will be shown on this page. The "Got it!" button should lead to the second frame instead of teams if the CO2 graph is present.