### PR TITLE
Contact admin modal not affected by testimonial modal structure chang…

### DIFF
--- a/src/assets/css/extras.css
+++ b/src/assets/css/extras.css
@@ -426,7 +426,7 @@
 .add-testimonial {
   cursor: pointer;
   height: 100%;
-  background: #fba930;
+  background: #f57b34;
   color: white;
   padding: 13px 20px;
   display: flex;

--- a/src/components/Pages/ActionsPage/StoryForm.js
+++ b/src/components/Pages/ActionsPage/StoryForm.js
@@ -213,7 +213,7 @@ class StoryForm extends React.Component {
               className="touchable-opacity"
               type="button"
               onClick={() => {
-                this.state.formReset && this.state.formReset();
+                this.props.close && this.props.close();
               }}
               containerStyle={{
                 padding: "10px 12px",

--- a/src/components/Pages/StoriesPage/StoriesPage.js
+++ b/src/components/Pages/StoriesPage/StoriesPage.js
@@ -16,8 +16,8 @@ import { NONE } from "../Widgets/MELightDropDown";
 import Tooltip from "../Widgets/CustomTooltip";
 import StorySheet from "./Story Sheet/StorySheet";
 import MECard from "../Widgets/MECard";
-import MEButton from "../Widgets/MEButton"
-import StoryFormButtonModal from "./StoryFormButtonModal"
+import MEButton from "../Widgets/MEButton";
+import StoryFormButtonModal from "./StoryFormButtonModal";
 class StoriesPage extends React.Component {
   constructor(props) {
     super(props);
@@ -49,7 +49,6 @@ class StoriesPage extends React.Component {
     this.setState({ checked_values: arr });
   }
 
-
   renderAddTestmonialBtn() {
     if (this.props.user) {
       return (
@@ -73,11 +72,11 @@ class StoriesPage extends React.Component {
   renderTestimonialForm() {
     if (this.props.user) {
       return (
-    <div className="every-day-flex">
-      <StoryFormButtonModal>Add Testimonial</StoryFormButtonModal>
-    </div>
-	  )
-	     }
+        <div className="every-day-flex">
+          <StoryFormButtonModal>Add Testimonial</StoryFormButtonModal>
+        </div>
+      );
+    }
   }
   scrollToForm() {
     document.getElementById("testimonial-area").scrollIntoView({
@@ -113,14 +112,21 @@ class StoriesPage extends React.Component {
           : story.user.preferred_name; //"...";
       // no anonymous testimonials   if (story?.anonymous) creatorName = "Anonymous";
       return (
-        <div  key={index.toString()}>
+        <div key={index.toString()}>
           <div key={index.toString()}>
             <MECard
               href={`${this.props.links.testimonials}#sheet-content-${story.id}`}
               className="extra-story-cards me-anime-move-from-left-fast"
               style={{ fontSize: "0.9rem", textTransform: "capitalise" }}
             >
-              {story.title} {story.is_published? "" : "(Pending Appr.)"}
+              {story.title}{" "}
+              {story.is_published ? (
+                ""
+              ) : (
+                <span style={{ color: "var(--app-theme-orange)" }}>
+                  (Pending Appr.)
+                </span>
+              )}
               <br />
               <small style={{ color: "green" }}>
                 <b>
@@ -210,7 +216,7 @@ class StoriesPage extends React.Component {
                   >
                     {this.renderStories(stories)}
                   </div>
-				  <div>{this.renderTestimonialForm()}</div>
+                  <div>{this.renderTestimonialForm()}</div>
 
                   <div id="testimonial-area" style={{ height: 100 }}></div>
                 </div>
@@ -268,9 +274,7 @@ class StoriesPage extends React.Component {
         }}
         className="animate-testimonial-sheet test-story-sheet"
       >
-        <StorySheet 
-        {...story} 
-        links={this.props.links} />
+        <StorySheet {...story} links={this.props.links} />
       </div>
     ));
   }

--- a/src/components/Pages/StoriesPage/StoryFormButtonModal.js
+++ b/src/components/Pages/StoriesPage/StoryFormButtonModal.js
@@ -4,7 +4,6 @@ import Modal from "react-bootstrap/Modal";
 import React, { Component } from "react";
 import Button from "react-bootstrap/Button";
 
-
 //refactored the submit testimonial form so now you can have a modal version of it
 class StoryFormButtonModal extends Component {
   constructor() {
@@ -45,8 +44,8 @@ class StoryFormButtonModal extends Component {
             this.TriggerModal(false);
           }}
         >
-
           <StoryForm
+            close={() => this.setState({ OpenModal: false })}
             draftTestimonialData={this.props.draftTestimonialData}
             TriggerSuccessNotification={(bool) =>
               this.TriggerSuccessNotification(bool)

--- a/src/components/Pages/Widgets/FormGenerator/MEFormGenerator.js
+++ b/src/components/Pages/Widgets/FormGenerator/MEFormGenerator.js
@@ -33,6 +33,7 @@ export const GOOD = "good";
  * @prop {bool} elevate | should the form be elevated or not?
  * @prop {bool} animate | should the form be animated or not?
  * @prop {object} info | any notification you would like to display below the form {icon, type ("good|bad"), text}
+ * @prop {function}  onMount | A function that exports some utility fxns and values from the form generator
  * @returns HTML Form event && form Content (e, content)
  *
  */
@@ -206,7 +207,8 @@ export default class FormGenerator extends Component {
     );
   }
   componentDidMount() {
-    const { fields } = this.props;
+    const { fields, onMount } = this.props;
+    onMount && onMount(this.resetForm)
     if (!fields) return;
     this.setDefaultValues();
     //sets props for form data when in edit mode 
@@ -429,39 +431,9 @@ export default class FormGenerator extends Component {
             <div>{this.displayInformation()}</div>
             <div>{this.displayImageWarning()}</div>
             <div style={{ display: "flex" }}>
-              <div style={{ margin: "auto" }}>
+              <div style={{ marginLeft: "auto" }}>
                 {moreActions}
-
-                {/*Added a clear form button because when you click edit testimonial button,
-                        you can edit the testimonial but there is no way to clear the form to submit a new
-                         testimonial with out refreshing the page */}   
                 <MEButton
-                  type="button"
-                  onClick={() => {this.resetForm()}}
-                  containerStyle={{
-                    padding: "10px 12px",
-                    fontSize: 18,
-                  }}
-                >
-                  Clear Form
-                </MEButton>
-
-				
-                <MEButton
-                  type="button"
-                  onClick={() => {this.props.TriggerModal(false)}}
-                  className="close-testimonial-modal-button"
-                  containerStyle={{
-                    padding: "10px 12px",
-                    fontSize: 18,
-                  }}
-                >
-                  Cancel 
-                </MEButton>
-
-
-                <MEButton
-                  className="submit-testimonial-button"
                   containerStyle={{
                     padding: "10px 12px",
                     fontSize: 18,


### PR DESCRIPTION
Stumbled on this.....
I think someone made direct tweaks to the `FormGenerator` cos they didnt know its a general component, and is being used in many places. So, they hardcoded  additions to the component to fit only testimonial creation, and now when you look at prod `Contact Admin` modal , it has the changes that were meant for testimonials, and the buttons do not work! 
If users click the "cancel" button it throws an error in the console -- cos the fxns do not exist
Here 
<img width="1927" alt="Screenshot 2022-02-18 at 13 29 32" src="https://user-images.githubusercontent.com/26961591/154679316-69da1bb1-76d2-4fc7-b9cd-e14d7bffa478.png">

This PR has the fixes, contact team is back to what it was, and I have removed the changes outside of the FormGenerator and made it specific to the implementation of the form generator in testimonial creation.
