### PR TITLE
Rich text editor in testimonials bug fixed

### DIFF
--- a/src/components/Pages/ActionsPage/StoryForm.js
+++ b/src/components/Pages/ActionsPage/StoryForm.js
@@ -147,7 +147,7 @@ class StoryForm extends React.Component {
         label:
           "Your name and email will be known to the Community Organizer but how would you like it to be displayed?",
         placeholder: "Name...",
-        value: this.props.user?.preferred_name,
+        defaultValue: this.props.user?.preferred_name,
         required: true,
       },
       {

--- a/src/components/Pages/Widgets/MERichTextEditor/MERichTextEditor.js
+++ b/src/components/Pages/Widgets/MERichTextEditor/MERichTextEditor.js
@@ -11,7 +11,7 @@ function MERichTextEditor({
   _generics,
 }) {
   const editorRef = useRef(null);
-  const [content, setContent] = useState("");
+  const [content, setContent] = useState(undefined);
   const [loading, setLoading] = useState(false);
 
   const handleOnChange = (text) => {
@@ -27,7 +27,7 @@ function MERichTextEditor({
   }, [onMount]);
 
   useEffect(() => {
-    if (content === "") setContent(value || defaultValue || initialValue || "");
+    if (content === undefined) setContent(value || defaultValue || initialValue || "");
   }, [value, defaultValue, initialValue, content]);
 
   return (


### PR DESCRIPTION
Related Ticket #1073 

- [ ] Now you can clear your whole story when you are creating testimonial 

Here: 

https://user-images.githubusercontent.com/26961591/179931227-26129262-b7ba-411e-b8eb-f96eb4d3b981.mov


closes #1073 
