### PR TITLE
Event is not displayed on HomePage if it is not published/live

### DIFF
--- a/src/components/Pages/HomePage/EventHomepageSection.js
+++ b/src/components/Pages/HomePage/EventHomepageSection.js
@@ -37,6 +37,7 @@ class Events extends React.Component {
     }
     if (events.length !== 0) {
       return events.map((event, index) => {
+        if (!event.is_published) return null;
         const dateString = dateFormatString(
           new Date(event.start_date_and_time),
           new Date(event.end_date_and_time)


### PR DESCRIPTION
####  Summary / Highlights
Event does not show up on Community HomePage if the event is not published.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)
Added if statement to check whether the event is published or not.

#### Testing Steps (Provide details on how your changes can be tested)
Locally tested by toggling an event's is_published field on and off with the admin portal and Django admin page.

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [x] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [x] I moved the linked issue to "QA Verification" now that it is ready to merge.
