### PR TITLE
Actions page should be sorted by rank

### DIFF
--- a/src/components/Pages/ActionsPage/ActionsPage.js
+++ b/src/components/Pages/ActionsPage/ActionsPage.js
@@ -403,8 +403,9 @@ class ActionsPage extends React.Component {
         </p>
       );
     }
+
     //returns a list of action components
-    return Object.keys(actions).map((key) => {
+    return Object.keys(actions.sort((a,b) => a.rank - b.rank)).map((key) => {
       var action = actions[key];
       return (
         <ActionCard


### PR DESCRIPTION
In the latest prod deploy,something has changed such that actions are not sorted by rank.  THis may also be a problem for vendors, testimonials too.  Was that sorting done in the API?