### PR TITLE
Community::Ensuring Consistent Spacing Between RichText Editor and Display

### DIFF
--- a/src/components/Pages/Widgets/MERichTextEditor/MERichTextEditor.js
+++ b/src/components/Pages/Widgets/MERichTextEditor/MERichTextEditor.js
@@ -53,6 +53,9 @@ function MERichTextEditor({
           height: 350,
           menubar: false,
           default_link_target: "_blank",
+          force_br_newlines: true,
+          force_p_newlines: false,
+          forced_root_block: "",
           plugins: [
             "advlist autolink lists link image charmap print preview anchor forecolor",
             "searchreplace visualblocks code fullscreen",


### PR DESCRIPTION
####  Related to [https://github.com/massenergize/frontend-portal/issues/1236](https://github.com/massenergize/frontend-portal/issues/1236)
#### Linked [PR](https://github.com/massenergize/frontend-portal/pull/1243)

#### Changes
- [x] Updated the tinyMCE's configuration to ensure pressing the return/enter key once does not create a paragraph 