### PR TITLE
testimonial submission on action page bug gone now

### DIFF
--- a/src/components/Pages/ActionsPage/OneActionPage.js
+++ b/src/components/Pages/ActionsPage/OneActionPage.js
@@ -47,7 +47,7 @@ import { handleTourCallback, smartString } from "../../Utils";
 import { isMobile } from "react-device-detect";
 import { ACTION_TO_AUTO_START } from "./ActionCard";
 import MEButton from "../Widgets/MEButton";
-import { ACTION } from "../../Constants";
+import { ACTION, TESTIMONIAL } from "../../Constants";
 
 /**
  * This page displays a single action and the cart of actions that have been added to todo and have been completed
@@ -940,6 +940,7 @@ class OneActionPage extends React.Component {
                   {this.props.user ? (
                     <div id="testimonials-form">
                       <StoryForm
+                        ModalType={TESTIMONIAL}
                         uid={this.props.user.id}
                         aid={action.id}
                         addStory={this.addStory}

--- a/src/components/Pages/ActionsPage/StoryForm.js
+++ b/src/components/Pages/ActionsPage/StoryForm.js
@@ -97,11 +97,6 @@ const ONLINE_FIELDS = [
   },
 ];
 
-
-
-
-
-
 //form fields for the action page
 var ActionFormData = [
   {
@@ -510,7 +505,7 @@ class StoryForm extends React.Component {
     ];
   }
 
-  getFieldNames = (data, formData)=>{
+  getFieldNames = (data, formData) => {
     let names = [];
     // eslint-disable-next-line
     formData.map((i) => {
@@ -525,7 +520,7 @@ class StoryForm extends React.Component {
       }
     });
     return names;
-  }
+  };
 
   processEditData = (body, formJson) => {
     if (
@@ -542,7 +537,7 @@ class StoryForm extends React.Component {
     }
     let names = this.getFieldNames(body, formJson);
     delete body?.ImgToDel;
-    let newBody = commonKeys( { ...body },names);
+    let newBody = commonKeys({ ...body }, names);
 
     return newBody;
   };
@@ -663,7 +658,6 @@ class StoryForm extends React.Component {
     const communityID = community ? { community_id: community.id } : {};
     const userEmail = user ? { user_email: user.email } : {};
     let body = { ...data, ...communityID };
-
     if (ModalType === TESTIMONIAL) {
       body = { ...body, rank: 0, ...userEmail };
       if (this.count(this.state.body) > this.state.limit) {
@@ -728,7 +722,11 @@ class StoryForm extends React.Component {
         return;
       }
 
-      if ( Date.parse(body.end_date_and_time) - Date.parse(body.start_date_and_time) < 0) {
+      if (
+        Date.parse(body.end_date_and_time) -
+          Date.parse(body.start_date_and_time) <
+        0
+      ) {
         this.setState({
           formNotification: {
             icon: "fa fa-times",
@@ -738,8 +736,10 @@ class StoryForm extends React.Component {
         });
         return;
       }
-      body.start_date_and_time = new Date(body?.start_date_and_time).toISOString()
-      body.end_date_and_time = new Date(body?.end_date_and_time).toISOString()
+      body.start_date_and_time = new Date(
+        body?.start_date_and_time
+      ).toISOString();
+      body.end_date_and_time = new Date(body?.end_date_and_time).toISOString();
       if (body?.id) {
         let newBody = this.processEditData(body, EventsFormData);
         body = { ...newBody, event_id: body?.id, ...communityID };
@@ -775,7 +775,6 @@ class StoryForm extends React.Component {
     });
     apiCall(Url, body).then((json) => {
       let name = ModalType?.toLowerCase() + "_id";
-
       if (json && json.success) {
         if (ModalType === VENDOR) {
           if (!body?.vendor_id) {
@@ -785,6 +784,14 @@ class StoryForm extends React.Component {
           celebrate({ show: true, duration: 8000 });
         }
         this.updateRedux(json?.data);
+        this.setState({
+          formNotification: {
+            icon: "fa check-circle",
+            type: "good",
+            text: "Sent! Admins will take a look and approve it soon. Cheers!",
+          },
+        });
+        resetForm && resetForm();
         if (TriggerSuccessNotification) {
           TriggerSuccessNotification(true);
           close && close();


### PR DESCRIPTION
## Context 
Submitting a testimonial via the testimonials tab on the one-actions page had a bug. Its fixed now. 
And it was because when were implementing the new user submitted content and the other things we just didnt notice that the form was being used in other places, so some new props that were introduced were not passed down on the actions page (i.e ModalType).  

- [X] It works now

## DEMO 



https://github.com/massenergize/frontend-portal/assets/26961591/f56449a4-4fcc-4a40-b4d2-e30bf9765bb1

