### PR TITLE
1267 - send test email from preferences page even for standard users

### DIFF
--- a/src/components/Pages/HomePage/Graphs.js
+++ b/src/components/Pages/HomePage/Graphs.js
@@ -87,8 +87,7 @@ class Graphs extends React.Component {
       const value = getCircleGraphData(
         this.props.goals,
         graphPars.key,
-        pref_eq,
-        display_prefs
+        pref_eq
       );
 
       const target = graphPars.target;

--- a/src/components/Pages/ImpactPage/ImpactPage.js
+++ b/src/components/Pages/ImpactPage/ImpactPage.js
@@ -305,14 +305,14 @@ class ImpactPage extends React.Component {
     const carbon_units = pref_eq.name;
 
     const data = [
-      createCircleGraphData(goal, "households", null, display_prefs),
-      createCircleGraphData(goal, "actions-completed", null, display_prefs),
-      createCircleGraphData(goal, "carbon-reduction", pref_eq, display_prefs),
+      createCircleGraphData(goal, "households", null),
+      createCircleGraphData(goal, "actions-completed", null),
+      createCircleGraphData(goal, "carbon-reduction", pref_eq),
     ];
     const values = [
-      getCircleGraphData(goal, "households", null, display_prefs),
-      getCircleGraphData(goal, "actions-completed", null, display_prefs),
-      getCircleGraphData(goal, "carbon-reduction", pref_eq, display_prefs),
+      getCircleGraphData(goal, "households", null),
+      getCircleGraphData(goal, "actions-completed", null),
+      getCircleGraphData(goal, "carbon-reduction", pref_eq),
     ];
     const percents = [
       parseInt((100 * values[0]) / goal.target_number_of_households),

--- a/src/components/Pages/Settings/RenderOptions.js
+++ b/src/components/Pages/Settings/RenderOptions.js
@@ -77,32 +77,30 @@ function RenderOptions({
       </MEButton>
 
       <Feature name={FLAGS.COMMUNICATION_PREFS}>
-        {(user?.is_super_admin || user?.is_community_admin)? (
-          <MEButton
-            onClick={() => {
-              apiCall("/downloads.sample.user_report", { community_id }).then(
-                (res) => {
-                  if (res?.data) {
-                    toggleToast({
-                      open: true,
-                      type: "success",
-                      message: "Your request has been sent to your email.",
-                    });
-                  } else {
-                    toggleToast({
-                      type: "error",
-                      open: true,
-                      message:
-                        "An error occurred while processing your request. Try again later.",
-                    });
-                  }
+        <MEButton
+          onClick={() => {
+            apiCall("/downloads.sample.user_report", { community_id }).then(
+              (res) => {
+                if (res?.data) {
+                  toggleToast({
+                    open: true,
+                    type: "success",
+                    message: "Your request has been sent to your email.",
+                  });
+                } else {
+                  toggleToast({
+                    type: "error",
+                    open: true,
+                    message:
+                      "An error occurred while processing your request. Try again later.",
+                  });
                 }
-              );
-            }}
-          >
-            <small>Send yourself a sample email</small>
-          </MEButton>
-        ): <></>}
+              }
+            );
+          }}
+        >
+          <small>Send yourself a sample email</small>
+        </MEButton>
       </Feature>
     </div>
   );

--- a/src/components/Utils.js
+++ b/src/components/Utils.js
@@ -531,38 +531,20 @@ export function locationFormatJSX(location) {
 export function getCircleGraphData(
   goalObj,
   which,
-  pref_eq = null,
-  display_prefs = {}
+  pref_eq = null
 ) {
   if (goalObj === null) return 0;
-  let value = 0;
+  //let value = 0;
   switch (which) {
     case "households": {
-      if (display_prefs.manual_households)
-        value += goalObj.initial_number_of_households;
-      if (display_prefs.state_households)
-        value += goalObj.attained_number_of_households;
-      if (display_prefs.platform_households)
-        value += goalObj.organic_attained_number_of_households;
-      return value;
+      return goalObj.displayed_number_of_households;
     }
     case "actions-completed": {
-      if (display_prefs.manual_actions)
-        value += goalObj.initial_number_of_actions;
-      if (display_prefs.state_actions)
-        value += goalObj.attained_number_of_actions;
-      if (display_prefs.platform_actions)
-        value += goalObj.organic_attained_number_of_actions;
-      return value;
+      return goalObj.displayed_number_of_actions;
     }
     case "carbon-reduction": {
       const factor = pref_eq?.value || PREF_EQ_DEFAULT.value; // hard coding tree equivalence if none chosen
-      if (display_prefs.manual_carbon)
-        value += goalObj.initial_carbon_footprint_reduction;
-      if (display_prefs.state_carbon)
-        value += goalObj.attained_carbon_footprint_reduction;
-      if (display_prefs.platform_carbon)
-        value += goalObj.organic_attained_carbon_footprint_reduction;
+      var value = goalObj.displayed_carbon_footprint_reduction;
       value = calcEQ(value, factor);
       return value;
     }
@@ -574,12 +556,11 @@ export function getCircleGraphData(
 export function createCircleGraphData(
   goalObj,
   which,
-  pref_eq = null,
-  display_prefs
+  pref_eq = null
 ) {
   if (goalObj === null) return {};
 
-  const value = getCircleGraphData(goalObj, which, pref_eq, display_prefs);
+  const value = getCircleGraphData(goalObj, which, pref_eq);
   switch (which) {
     case "households": {
       // if everything is zero, we dont want the graph to not show, we want a big ball of greyish NOTHING... loool


### PR DESCRIPTION
Two issue fixed:
#1252 - use the displayed impact as calculated in the API (so all front ends show the same values) 
#1267 - any user can send the sample email from their preferences page


