### PR TITLE
Fix/Add loading circle for stories without data

### DIFF
--- a/src/components/Pages/StoriesPage/StoriesPage.js
+++ b/src/components/Pages/StoriesPage/StoriesPage.js
@@ -256,6 +256,9 @@ class StoriesPage extends React.Component {
     if (!this.props.tagCols) {
       return <LoadingCircle />;
     }
+    if (!this.props.stories) {
+      return <LoadingCircle />;
+    }
 
     const title = pageData && pageData.title ? pageData.title : "Testimonials";
     const sub_title =


### PR DESCRIPTION
####  Summary / Highlights
This pull request adds a loading circle for stories without data in the StoriesPage component.
#### Details (Give details about what this PR accomplishes, include any screenshots etc)

https://github.com/massenergize/frontend-portal/assets/42780120/e472d992-a773-4c13-9088-c3bbe03a2061


#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
