### PR TITLE
Google Tag Manager initialization with user properties defined

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,8 +49,20 @@
       gtag('set', 'user_properties', {user_type: "anonymous"});
 
     </script>
+    <title>Massenergize</title>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-NZHVXZRT');</script>
+    <!-- End Google Tag Manager -->
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NZHVXZRT"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
   </body>

--- a/public/index.html
+++ b/public/index.html
@@ -61,14 +61,14 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-NZHVXZRT');</script>
+    })(window,document,'script','dataLayer','GTM-KZR4KTGR');</script>
     <!-- End Google Tag Manager -->
   </head>
 
   <body>
     <!-- Google Tag Manager (noscript) -->
     <!-- BHN - what does this section do? -->
-    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NZHVXZRT"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KZR4KTGR"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
 

--- a/public/index.html
+++ b/public/index.html
@@ -30,32 +30,6 @@
 
     <title>MassEnergize</title>
 
-    
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-  <!--  
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140128910-2"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'UA-140128910-2');
-    </script>
-  -->
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <!-- 
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JQ74G6E1XB"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-    
-      gtag('config', 'G-JQ74G6E1XB');
-      gtag('set', 'user_properties', {user_type: "anonymous"});     //// BHN - THIS IS NEEDED
-
-    </script>
-    -->
-
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -63,6 +37,18 @@
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-KZR4KTGR');</script>
     <!-- End Google Tag Manager -->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JQ74G6E1XB"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+    
+      gtag('config', 'G-JQ74G6E1XB');
+      gtag('set', 'user_properties', {user_type: "anonymous"});
+
+    </script>
   </head>
 
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -29,7 +29,10 @@
    
 
     <title>MassEnergize</title>
+
+    
     <!-- Global site tag (gtag.js) - Google Analytics -->
+  <!--  
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-140128910-2"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
@@ -38,18 +41,21 @@
 
       gtag('config', 'UA-140128910-2');
     </script>
+  -->
     <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JQ74G6E1XB"></script>
+    <!-- 
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JQ74G6E1XB"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
     
       gtag('config', 'G-JQ74G6E1XB');
-      gtag('set', 'user_properties', {user_type: "anonymous"});
+      gtag('set', 'user_properties', {user_type: "anonymous"});     //// BHN - THIS IS NEEDED
 
     </script>
-    <title>Massenergize</title>
+    -->
+
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -58,11 +64,14 @@
     })(window,document,'script','dataLayer','GTM-NZHVXZRT');</script>
     <!-- End Google Tag Manager -->
   </head>
+
   <body>
     <!-- Google Tag Manager (noscript) -->
+    <!-- BHN - what does this section do? -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-NZHVXZRT"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     <!-- End Google Tag Manager (noscript) -->
+
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
   </body>


### PR DESCRIPTION
####  Summary / Highlights
Addresses issue #1263 (removing the Universal Analytics initialization which is obsolete), together with installing a Google tag Manager container and the initilalization of the GA4 user properties

#### Details (Give details about what this PR accomplishes, include any screenshots etc)
We will be using Google Tag Manager (googletagmanager.google.com) with a separate tag container for each subdomain (community, campaigns, admin and the wordpress site). 

A tag container was created for the community site, and this PR installs it.

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [ ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [x] I moved the linked issue to "Local testing" now that it is ready to merge.
