### PR TITLE
Hotfix: Improve event shared detection on EventsPage

### DIFF
--- a/src/components/Pages/EventsPage/EventsPageReal.js
+++ b/src/components/Pages/EventsPage/EventsPageReal.js
@@ -465,6 +465,11 @@ class EventsPage extends React.Component {
         );
         const recurringDetailString = recurringDetails(event);
 
+        const isShared = thisCommunity?.id?.toString() !== event?.community?.id?.toString();
+        console.log("=== COMMUNITY ===", thisCommunity?.id?.toString(), event?.community?.id?.toString())
+
+        console.log("=== IS SHARED ===", isShared)
+
         return (
           // can we format the cancelled message to be an overlay instead of going above?
           <div
@@ -496,7 +501,7 @@ class EventsPage extends React.Component {
               user={this.props.user}
               dropDirection="up"
               toggleGuestAuthDialog={this.props.toggleGuestAuthDialog}
-              isShared={thisCommunity?.id !== event?.community?.id}
+              isShared={isShared}
               onEditButtonClicked={() => {
                 let reConstEvent = {
                   ...event,

--- a/src/config/firebaseConfig.js
+++ b/src/config/firebaseConfig.js
@@ -29,7 +29,7 @@ if (IS_PROD || IS_CANARY) {
     appId: "1:72842344535:web:9b1517b1b3d2e818",
   };
 }
-console.log(" co",firebaseConfig );
+console.log("co:"," just checking......" );
 
 firebase.initializeApp(firebaseConfig);
 


### PR DESCRIPTION
####  Summary / Highlights
In `EventsPageReal.js`, the method for determining if an event is shared between communities has been moved from inline to its own variable to enhance readability and debugging. Console logs have been added for troubleshooting and the variable is used to toggle the `isShared` property.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
