### PR TITLE
Hotfix: Community name showing as undefined in prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ cypress/videos
 cypress/reports
 
 .netlify/
+.idea/

--- a/src/components/Menu/NavBarBurger.js
+++ b/src/components/Menu/NavBarBurger.js
@@ -42,10 +42,10 @@ class NavBarBurger extends React.Component {
     this.setState({ menuOpen: !this.state.menuOpen });
   }
   render() {
-    const { links, community, pageData} = this.props;
-    var communitylogo = community?.logo?.url;
+    const { links, community} = this.props;
+    const communitylogo = community?.logo?.url;
     var header = null;
-    var communityName = pageData.community.name || "communities";
+    const communityName = community.name || "communities";
 
     const styles = {
       container: {

--- a/src/components/Pages/EventsPage/EventsPageReal.js
+++ b/src/components/Pages/EventsPage/EventsPageReal.js
@@ -118,7 +118,7 @@ class EventsPage extends React.Component {
     this.props.toggleGuestAuthDialog(true);
   }
   renderAddForm = () => {
-    const { user, events, updateEventsInRedux, communityData } = this.props;
+    const { user, events, updateEventsInRedux, community } = this.props;
     let _props = {};
     if (!user) {
     _props = {
@@ -136,7 +136,7 @@ class EventsPage extends React.Component {
         }}
         {..._props}
       >
-        <AddButton type={EVENT} community={communityData?.community?.name} />
+        <AddButton type={EVENT} community={community?.name} />
       </StoryFormButtonModal>
     );
   };
@@ -219,14 +219,14 @@ class EventsPage extends React.Component {
       return 0;
     };
 
-    const { communityData } = this.props;
+    const { community } = this.props;
     return (
       <>
         {Seo({
           title: "Events",
           description: "",
           url: `${window.location.pathname}`,
-          site_name: communityData?.community?.name,
+          site_name: community?.name,
         })}
         <div
           className="boxed_wrapper test-events-page-wrapper"
@@ -430,8 +430,7 @@ class EventsPage extends React.Component {
       let idsArr = ids.split("-");
       events = events.filter((event) => idsArr.includes(event.id.toString()));
     }
-
-    const thisCommunity = this.props?.pageData?.community;
+    const thisCommunity = this.props?.community;
     if (this.state.mirror_events.length === 0) {
       events = this.state.check_values === null ? this.props.events : events;
     }
@@ -466,10 +465,6 @@ class EventsPage extends React.Component {
         const recurringDetailString = recurringDetails(event);
 
         const isShared = thisCommunity?.id?.toString() !== event?.community?.id?.toString();
-        console.log("=== COMMUNITY ===", thisCommunity?.id?.toString(), event?.community?.id?.toString())
-
-        console.log("=== IS SHARED ===", isShared)
-
         return (
           // can we format the cancelled message to be an overlay instead of going above?
           <div
@@ -557,7 +552,7 @@ const mapStoreToProps = (store) => {
     eventRSVPs: store.page.rsvps,
     links: store.links,
     tagCols: filterTagCollections(store.page.events, store.page.tagCols),
-    communityData: store.page.communityData,
+    community: store.page.community,
   };
 };
 export default connect(mapStoreToProps, {

--- a/src/components/Pages/EventsPage/OneEventPage.js
+++ b/src/components/Pages/EventsPage/OneEventPage.js
@@ -325,8 +325,8 @@ class OneEventPage extends React.Component {
     );
   };
   renderEvent(event) {
-    const { user, toggleGuestAuthDialog, pageData } = this.props;
-    const isShared = pageData?.community?.id !== event?.community?.id;
+    const { user, toggleGuestAuthDialog,community } = this.props;
+    const isShared = community?.id !== event?.community?.id;
 
     let dateString = dateFormatString(
       new Date(event.start_date_and_time),
@@ -579,7 +579,6 @@ const mapStoreToProps = (store) => {
     user: store.user.info,
     events: store.page.events,
     links: store.links,
-    pageData: store.page.eventsPage,
     community: store.page.community,
   };
 };

--- a/src/components/Pages/TeamsPage/TeamsPage.js
+++ b/src/components/Pages/TeamsPage/TeamsPage.js
@@ -90,9 +90,8 @@ class TeamsPage extends React.Component {
   componentDidMount() {
     window.gtag('set', 'user_properties', {page_title: "TeamsPage"});
     const subdomain =
-      this.props.communityData &&
-      this.props.communityData.community &&
-      this.props.communityData.community.subdomain;
+      this.props.community &&
+      this.props.community.subdomain;
     this.getAnyUpdatedTeamChanges(subdomain);
   }
 
@@ -103,7 +102,8 @@ class TeamsPage extends React.Component {
   }
 
   render() {
-    const { teamsStats, communityData, links, pageData, user } = this.props;
+    const { teamsStats, links, pageData, user, community } = this.props;
+
     if (pageData == null) return <LoadingCircle />;
     if (teamsStats === null) {
       return (
@@ -118,7 +118,7 @@ class TeamsPage extends React.Component {
     const title =
       pageData && pageData.title
         ? pageData.title
-        : "Teams in " + communityData.community.name;
+        : "Teams in " +community.name;
     const sub_title =
       pageData && pageData.sub_title
         ? pageData.sub_title
@@ -133,7 +133,7 @@ class TeamsPage extends React.Component {
           title: "Teams",
           description: "",
           url: `${window.location.pathname}`,
-          site_name: communityData.community.name,
+          site_name: community.name,
         })}
         {redirectID && <Redirect to={`${links.teams + "/" + redirectID} `} />}
         {createTeamModalOpen && (
@@ -208,7 +208,7 @@ class TeamsPage extends React.Component {
                       text={"Team"}
                       type={"team"}
                       className="phone-vanish"
-                      community={communityData?.community?.name}
+                      community={community?.name}
                     />
                     // <MEButton
                     //   style={{ width: "100%", margin: 0 }}
@@ -461,6 +461,7 @@ const mapStoreToProps = (store) => {
     communityData: store.page.homePage,
     pageData: store.page.teamsPage,
     pref_eq: store.user.pref_equivalence || PREF_EQ_DEFAULT,
+    community: store.page.community,
   };
 };
 const mapDispatchToProps = {


### PR DESCRIPTION
####  Summary / Highlights
This PR addresses 

- The issue of incorrect community name display on the team's page. The community name is now correctly fetched and displayed. 
- The bug setting all events in Prod show as shared when they are not.

#### Details (Give details about what this PR accomplishes, include any screenshots etc)

#### Testing Steps (Provide details on how your changes can be tested)

#### Requirements (place an `x` in each `[ ]`)
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.
