### PR TITLE
Fix: #1350 Icon box links not working properly

### DIFF
--- a/src/components/Pages/HomePage/HomePage.js
+++ b/src/components/Pages/HomePage/HomePage.js
@@ -82,8 +82,6 @@ class HomePage extends React.Component {
     const { hostname } = new URL(window.location.href);
     const isNotCustom = URLS.NONE_CUSTOM_WEBSITE_LIST.has(hostname);
 
-    console.log("Lets see something", isNotCustom);
-
     const prefix =
       (isNotCustom || !__is_custom_site) && subdomain ? `/${subdomain}` : "";
 

--- a/src/components/Pages/HomePage/HomePage.js
+++ b/src/components/Pages/HomePage/HomePage.js
@@ -305,7 +305,6 @@ class HomePage extends React.Component {
                 title="Get started - See your local options!"
                 boxes={iconQuickLinks}
                 prefix={prefix}
-                is_custom_site={__is_custom_site}
               />
             </div>
           ) : null}

--- a/src/components/Pages/HomePage/HomePage.js
+++ b/src/components/Pages/HomePage/HomePage.js
@@ -79,8 +79,14 @@ class HomePage extends React.Component {
     const { __is_custom_site, community } = this.props;
     const { subdomain } = community || {};
 
-    const prefix = !__is_custom_site && subdomain ? `/${subdomain}` : "";
-    
+    const { hostname } = new URL(window.location.href);
+    const isNotCustom = URLS.NONE_CUSTOM_WEBSITE_LIST.has(hostname);
+
+    console.log("Lets see something", isNotCustom);
+
+    const prefix =
+      (isNotCustom || !__is_custom_site) && subdomain ? `/${subdomain}` : "";
+
     // if(this.state.loading) return (<LoadingCircle />);
 
     if (!this.props.pageData) {
@@ -302,6 +308,7 @@ class HomePage extends React.Component {
                 title="Get started - See your local options!"
                 boxes={iconQuickLinks}
                 prefix={prefix}
+                is_custom_site={__is_custom_site}
               />
             </div>
           ) : null}

--- a/src/components/Pages/HomePage/HomePage.js
+++ b/src/components/Pages/HomePage/HomePage.js
@@ -82,8 +82,7 @@ class HomePage extends React.Component {
     const { hostname } = new URL(window.location.href);
     const isNotCustom = URLS.NONE_CUSTOM_WEBSITE_LIST.has(hostname);
 
-    const prefix =
-      (isNotCustom || !__is_custom_site) && subdomain ? `/${subdomain}` : "";
+    const prefix = isNotCustom && subdomain ? `/${subdomain}` : "";
 
     // if(this.state.loading) return (<LoadingCircle />);
 


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/massenergize/massenergize-campaigns/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->
####  Summary / Highlights

I checked and found that we are actually checking for all the weird cases for user input. Looks like the fault was from `__is_custom_site` -- it cant be trusted. So I just implemented a better check for the app to accurately determine when we are on a MassEnergize domain... then show the appropriate link. (i.e. prefix with subdomain) 

#### Details (Give details about what this PR accomplishes, include any screenshots etc.)


#### Testing Steps (Provide details on how your changes can be tested)


#### Requirements
<!-- (Update "[ ]" to "[x]" to check a box) -->
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Performance improvement
- [ ] Feature removal
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch or to a feature branch, _not_ the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the
  issue number)
- [ ] All tests are
  passing: 
- [ ] New/updated tests are included

**Other information: Any otherthing we need to know**


