### PR TITLE
Fix: #1328,#1389,#1345 Typo, Nav showing when there are no menu items etc.

### DIFF
--- a/src/components/Constants.js
+++ b/src/components/Constants.js
@@ -20,7 +20,7 @@ export const COPYRIGHT_OPTIONS = {
   YES_CHECKED: {
     value: true,
     key: "YES_CHECKED",
-    text: "Yes. I have checked that the image is nto copyright protected.",
+    text: "Yes. I have checked that the image is not copyright protected.",
     notes: "Checked that the image is not copyright protected",
   },
   NO: {

--- a/src/components/Menu/NavBarBurger.js
+++ b/src/components/Menu/NavBarBurger.js
@@ -47,6 +47,7 @@ class NavBarBurger extends React.Component {
     const { links, community } = this.props;
     const communityName = community.name || "communities";
     const { isChild } = options || {};
+    if (!menuItems || !menuItems.length) return null;
     return menuItems?.map((val, index) => {
       if (val.children) {
         return (
@@ -136,6 +137,8 @@ class NavBarBurger extends React.Component {
         </MenuItem>
       );
     });
+
+    const noMenus = this.props.navLinks?.length === 0;
     return (
       <div>
         <nav
@@ -190,16 +193,16 @@ class NavBarBurger extends React.Component {
                   <div style={{ margin: "auto 0 auto auto" }}>
                     <div style={styles.container}>
                       <MenuButton
+                        hide={noMenus}
                         open={this.state.menuOpen}
                         onClick={() => this.handleMenuClick()}
                         color="#333"
+                        style={{ display: noMenus ? "none" : "flex" }}
                       />
                       {this.renderLogin()}
                     </div>
                     {/* <Menu open={this.state.menuOpen}>{menuItems}</Menu> */}
                     <Menu open={this.state.menuOpen}>
-                      {" "}
-                      {/* {this.renderMenuItems(this.props.navLinks)} */}
                       {this.renderMenuForBurgeredState(this.props.navLinks)}
                     </Menu>
                   </div>
@@ -790,6 +793,7 @@ class MenuButton extends React.Component {
         marginTop: "8px",
       },
     };
+    if (this.props.hide) return <></>;
     return (
       <div
         style={styles.container}

--- a/src/components/Menu/NavBarBurger.js
+++ b/src/components/Menu/NavBarBurger.js
@@ -261,6 +261,7 @@ class NavBarBurger extends React.Component {
       if (navLink.children && navLink.children.length > 0)
         return (
           <NavDropdown
+            id={linkId}
             className={`c-d-t ${isChild ? "c-d-t-as-child" : ""}`}
             key={linkId}
             title={
@@ -276,6 +277,7 @@ class NavBarBurger extends React.Component {
 
       return (
         <Nav.Link
+          id={linkId}
           onClick={(e) => {
             e.preventDefault();
             if (is_link_external) window.location = link;
@@ -567,6 +569,7 @@ class SubMenuItem extends React.Component {
       if (item.special) {
         return (
           <MenuItem
+            id={item?.id}
             key={key}
             onClick={(e) => {
               e.preventDefault();
@@ -583,6 +586,7 @@ class SubMenuItem extends React.Component {
           : "My Community 2";
         return (
           <MenuItem
+            id={item?.id}
             key={key}
             href={item.link}
             onClick={this.props.clickHandler}
@@ -661,6 +665,7 @@ class MenuItem extends React.Component {
     return (
       <div style={styles.container}>
         <Link
+          id={this.props.id}
           className="width-100"
           style={styles.menuItem}
           onMouseEnter={() => {

--- a/src/components/Menu/SubscribeForm.js
+++ b/src/components/Menu/SubscribeForm.js
@@ -45,7 +45,7 @@ class SubscribeForm extends React.Component {
                     />
                     <button type="submit"><i className="fa fa-paper-plane"></i></button>
                 </form>
-                <p className="cool-font" style = {{color:"white"}} >{this.state.message}</p>
+                <p className="cool-font" style = {{color:"#b2b2b2"}} >{this.state.message}</p>
             </div>
         );
     }

--- a/src/components/Menu/SubscribeForm.js
+++ b/src/components/Menu/SubscribeForm.js
@@ -45,7 +45,7 @@ class SubscribeForm extends React.Component {
                     />
                     <button type="submit"><i className="fa fa-paper-plane"></i></button>
                 </form>
-                <p className="cool-font" >{this.state.message}</p>
+                <p className="cool-font" style = {{color:"white"}} >{this.state.message}</p>
             </div>
         );
     }


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/massenergize/massenergize-campaigns/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->
####  Summary / Highlights

Fixed the following: 
#1328 , #1389, #1345, Now includes #1398


#### Details (Give details about what this PR accomplishes, include any screenshots etc.)


#### Testing Steps (Provide details on how your changes can be tested)


#### Requirements
<!-- (Update "[ ]" to "[x]" to check a box) -->
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [ ] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.


**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Performance improvement
- [ ] Feature removal
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `dev` branch or to a feature branch, _not_ the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the
  issue number)
- [ ] All tests are
  passing: 
- [ ] New/updated tests are included

**Other information: Any otherthing we need to know**


