### PR TITLE
Feat: Make breadcrumb "home" navigate to custom home value when set.

### DIFF
--- a/src/components/Shared/BreadCrumbBar.js
+++ b/src/components/Shared/BreadCrumbBar.js
@@ -1,45 +1,62 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
-import { connect } from 'react-redux'
+import React from "react";
+import { Link } from "react-router-dom";
+import { connect } from "react-redux";
+import { withRouter } from "react-router-dom/cjs/react-router-dom.min";
 class BreadCrumbBar extends React.Component {
-	render() {
-		return (
-			<div className="breadcumb-wrapper responsive-bread-crumb" >
-				<div className="container">
-					<div className="pull-left">
-						<ul className="list-inline link-list">
-							<li>
-								<Link to={this.props.reduxLinks.home} className='link'> Home </Link>
-							</li>
-							{Object.keys(this.props.links).map(key => {
-								const link = this.props.links[key];
-								if (link.link) {
-									return (
-										<li key={key}>
-											<Link to={`${link.link}`} className='link'>{link.name}</Link>
-										</li>
-									);
-								} else if (link.name) {
-									return (
-										<li key={key} style={{color:'#333'}}>
-											{link.name}
-										</li>
-									);
-								}else{
-									return <div />
-								}
-							})}
-						</ul>
-					</div>
-
-				</div>
-			</div>
-		);
-	}
+  render() {
+    const { community } = this.props;
+    const customHomeLink = community?.community_logo_link;
+    return (
+      <div className="breadcumb-wrapper responsive-bread-crumb">
+        <div className="container">
+          <div className="pull-left">
+            <ul className="list-inline link-list">
+              <li>
+                <Link
+                  onClick={(e) => {
+                    e.preventDefault();
+                    if (customHomeLink)
+                      return (window.location.href = customHomeLink);
+                    this.props.history.push(this.props.reduxLinks.home);
+                  }}
+                  to={this.props.reduxLinks.home}
+                  className="link"
+                >
+                  {" "}
+                  Home{" "}
+                </Link>
+              </li>
+              {Object.keys(this.props.links).map((key) => {
+                const link = this.props.links[key];
+                if (link.link) {
+                  return (
+                    <li key={key}>
+                      <Link to={`${link.link}`} className="link">
+                        {link.name}
+                      </Link>
+                    </li>
+                  );
+                } else if (link.name) {
+                  return (
+                    <li key={key} style={{ color: "#333" }}>
+                      {link.name}
+                    </li>
+                  );
+                } else {
+                  return <div />;
+                }
+              })}
+            </ul>
+          </div>
+        </div>
+      </div>
+    );
+  }
 }
 const mapStoreToProps = (store) => {
-	return ({
-		reduxLinks: store.links
-	});
-}
-export default connect(mapStoreToProps)(BreadCrumbBar);
+  return {
+    reduxLinks: store.links,
+    community: store.page.community,
+  };
+};
+export default connect(mapStoreToProps)(withRouter(BreadCrumbBar));


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/massenergize/massenergize-campaigns/main/.github/CONTRIBUTING.md#pull-request-guidelines
-->
####  Summary / Highlights
✅ Make breadcrumb "home" navigate to custom home value when set. Otherwise it will go to the default MassEnergize page

#### Details (Give details about what this PR accomplishes, include any screenshots etc.)


#### Testing Steps (Provide details on how your changes can be tested)


#### Requirements
<!-- (Update "[ ]" to "[x]" to check a box) -->
* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've tested my changes manually.
* [ ] I've added unit tests to my PR.

##### Transparency ([Project board](https://github.com/orgs/massenergize/projects/7/views/2))
* [x] I've given my PR a meaningful title.
* [x] I linked this PR to the relevant issue.
* [ ] I moved the linked issue from the "Sprint backlog" to "In progress" when I started this.
* [ ] I moved the linked issue to "QA Verification" now that it is ready to merge.


**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Performance improvement
- [ ] Feature removal
- [ ] Code style update
- [ ] Refactor
- [ ] Docs
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [X] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `dev` branch or to a feature branch, _not_ the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the
  issue number)
- [ ] All tests are
  passing: 
- [ ] New/updated tests are included

**Other information: Any otherthing we need to know**


