### PR TITLE
Prevent displaying action for shared testimonials

### DIFF
--- a/src/components/Pages/StoriesPage/OneTestimonialV2.js
+++ b/src/components/Pages/StoriesPage/OneTestimonialV2.js
@@ -16,6 +16,8 @@ function OneTestimonialV2({
   user,
 }) {
   let isShared = community?.id !== story?.community?.id;
+
+  
   const inEditMode = !story?.is_published && user;
   return (
     <div>
@@ -44,7 +46,7 @@ function OneTestimonialV2({
         />
         <RichTextView html={story?.body} />
 
-        {story?.action && (
+        {story?.action && !isShared &&  (
           <div className="related-area">
             <div style={{ marginTop: 10, width: "100%" }}>
               <h5 className="t-area-title flex-row">

--- a/src/components/Pages/StoriesPage/TestimonialsCardV2.js
+++ b/src/components/Pages/StoriesPage/TestimonialsCardV2.js
@@ -88,7 +88,7 @@ function TestimonialsCardV2({ story }) {
             {getHumanFriendlyDate(story?.created_at)}
           </span>
 
-          {action?.title && (
+          {action?.title && !isShared && (
             <span>
               Action:
               <Link


### PR DESCRIPTION
This pull request introduces a small update to the `StoriesPage` components to conditionally hide action-related elements when a testimonial is shared across communities. The key changes ensure that actions are only displayed if the testimonial belongs to the same community.

### Conditional Rendering Updates:
* **`OneTestimonialV2.js`**: Added a condition to hide the `story.action` section when the testimonial is shared across communities (`!isShared`) and removed unnecessary whitespace. [[1]](diffhunk://#diff-69315c051c9ac773f3ed41237ac26f60534d380afc2d324918d6fd8f798d601bR19-R20) [[2]](diffhunk://#diff-69315c051c9ac773f3ed41237ac26f60534d380afc2d324918d6fd8f798d601bL47-R49)
* **`TestimonialsCardV2.js`**: Updated the conditional rendering of `action.title` to include the `!isShared` check, ensuring actions are not displayed for shared testimonials.